### PR TITLE
Add Main Topic and Detailed Task Suggestions to AI Chat Response

### DIFF
--- a/app/schemas/ai_schema.py
+++ b/app/schemas/ai_schema.py
@@ -6,6 +6,7 @@ class AIChatRequest(BaseModel):
 
 class AIChatResponse(BaseModel):
     reply: str
+    main_topic: str
     sub_topics: List[str]
     moodboard_url: Optional[str] = None
     itinerary: Optional[List[Dict[str, Any]]] = None
@@ -21,6 +22,10 @@ class AIGeneratedTask(BaseModel):
     sub_topic: str
     task: str
     tag: str
+    suggested_position: Optional[str] = ""
+    lighting_condition: Optional[str] = ""
+    shooting_technique: Optional[str] = ""
+    recommended_time: Optional[str] = ""
 
 class AIGeneratedTaskList(BaseModel):
     tasks: List[AIGeneratedTask]


### PR DESCRIPTION
### Changes
- Updated `AIChatResponse` schema to include:
  - `main_topic` field for identifying the user's original shooting theme.
- Extended `AIGeneratedTask` schema to support:
  - `suggested_position`
  - `lighting_condition`
  - `shooting_technique`
  - `recommended_time`
- Modified `ai_service.py` to:
  - Extract and return `main_topic` from Gemini's response.
  - Parse and return detailed task suggestions with new fields.
